### PR TITLE
Add support for GMT formatted offsets

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -497,25 +497,41 @@ iterRunes:
 			if t, err := time.Parse("2006-01-02 15:04:05 UTC", datestr); err == nil {
 				return t, nil
 			} else {
-				return time.Time{}, err
+				if t, err := time.Parse("2006-01-02 15:04:05 GMT", datestr); err == nil {
+					return t, nil
+				} else {
+					return time.Time{}, err
+				}
 			}
 		case len("2015-02-18 00:12:00 +0000 UTC"):
 			if t, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", datestr); err == nil {
 				return t, nil
 			} else {
-				return time.Time{}, err
+				if t, err = time.Parse("2006-01-02 15:04:05 +0000 GMT", datestr); err == nil {
+					return t, nil
+				} else {
+					return time.Time{}, err
+				}
 			}
 		case len("2015-09-30 18:48:56.35272715 +0000 UTC"):
 			if t, err := time.Parse("2006-01-02 15:04:05.00000000 +0000 UTC", datestr); err == nil {
 				return t, nil
 			} else {
-				return time.Time{}, err
+				if t, err := time.Parse("2006-01-02 15:04:05.00000000 +0000 GMT", datestr); err == nil {
+					return t, nil
+				} else {
+					return time.Time{}, err
+				}
 			}
 		case len("2015-06-25 01:25:37.115208593 +0000 UTC"):
 			if t, err := time.Parse("2006-01-02 15:04:05.000000000 +0000 UTC", datestr); err == nil {
 				return t, nil
 			} else {
-				return time.Time{}, err
+				if t, err := time.Parse("2006-01-02 15:04:05.000000000 +0000 GMT", datestr); err == nil {
+					return t, nil
+				} else {
+					return time.Time{}, err
+				}
 			}
 		}
 	case ST_DIGITSLASH: // starts digit then slash 02/ (but nothing else)

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -117,6 +117,10 @@ func TestParse(t *testing.T) {
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
 	assert.T(t, "2006-01-02 22:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
+	ts, err = ParseAny("2015-02-18 00:12:00 +0000 GMT")
+	assert.Tf(t, err == nil, "%v", err)
+	assert.T(t, "2015-02-18 00:12:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
 	// Golang Native Format
 	ts, err = ParseAny("2015-02-18 00:12:00 +0000 UTC")
 	assert.Tf(t, err == nil, "%v", err)
@@ -273,6 +277,11 @@ func TestParse(t *testing.T) {
 	assert.T(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-12-16 06:20:00 UTC")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-12-16 06:20:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-12-16 06:20:00 GMT")
 	assert.Tf(t, err == nil, "%v", err)
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
 	assert.T(t, "2014-12-16 06:20:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))


### PR DESCRIPTION
Looks like we can still very well expect to receive GMT formatted offsets (vs. UTC): https://github.com/golang/go/issues/13781