### PR TITLE
Fix slash am/pm times

### DIFF
--- a/parseany_test.go
+++ b/parseany_test.go
@@ -172,7 +172,19 @@ func TestParse(t *testing.T) {
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
 	assert.T(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
-	ts, err = ParseAny("8/8/1965 12:00:00 AM")
+	ts, err = ParseAny("8/8/1965 01:00:01 PM")
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
+	assert.T(t, "1965-08-08 13:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("8/8/1965 12:00:01 AM")
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
+	assert.T(t, "1965-08-08 12:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("8/8/1965 01:00 PM")
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
+	assert.T(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("8/8/1965 12:00 AM")
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
 	assert.T(t, "1965-08-08 12:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -167,10 +167,10 @@ func TestParse(t *testing.T) {
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
 	assert.T(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
-	ts, err = ParseAny("04/2/2014 03:00:51")
+	ts, err = ParseAny("04/2/2014 4:00:51")
 	assert.Tf(t, err == nil, "%v", err)
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert.T(t, "2014-04-02 04:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 01:00:01 PM")
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
@@ -178,15 +178,19 @@ func TestParse(t *testing.T) {
 
 	ts, err = ParseAny("8/8/1965 12:00:01 AM")
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 12:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert.T(t, "1965-08-08 00:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 01:00 PM")
+	//	u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
+	assert.T(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("8/8/1965 1:00 PM")
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
 	assert.T(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 12:00 AM")
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 12:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert.T(t, "1965-08-08 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("4/02/2014 03:00:51")
 	assert.Tf(t, err == nil, "%v", err)


### PR DESCRIPTION
Add parsing for "8/8/1965 01:00 PM", which was returning a `unable to parse extra " PM"` error.
Also fixes parsing for "8/8/1965 01:00:00 PM", which wasn't adjusting the time by 12 hours for PM times. 