### PR TITLE
Add more date dot times

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -540,9 +540,9 @@ iterRunes:
 				t, err = time.Parse("2006-01-02 15:04:05 GMT", datestr)
 			}
 		case len("2015-02-18 00:12:00 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05 -0700 GMT", datestr)
 			}
 		}
 		if err == nil {
@@ -661,48 +661,48 @@ iterRunes:
 
 		switch len(datestr) {
 		case len("2015-06-25 01:25:37.123456789 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.000000000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.000000000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.000000000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.000000000 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.12345678 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.00000000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.00000000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.00000000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.00000000 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.1234567 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.0000000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.0000000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.0000000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.0000000 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.123456 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.000000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.000000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.000000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.000000 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.12345 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.00000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.00000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.00000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.00000 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.1234 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.0000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.0000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.0000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.0000 -0700 GMT", datestr)
 			}
-			t, err = time.Parse("2006-01-02 15:04:05.000 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.000 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.000 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.000 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.12 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.00 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.00 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.00 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.00 -0700 GMT", datestr)
 			}
 		case len("2015-09-30 18:48:56.1 +0000 UTC"):
-			t, err = time.Parse("2006-01-02 15:04:05.0 +0000 UTC", datestr)
+			t, err = time.Parse("2006-01-02 15:04:05.0 -0700 UTC", datestr)
 			if err != nil {
-				t, err = time.Parse("2006-01-02 15:04:05.0 +0000 GMT", datestr)
+				t, err = time.Parse("2006-01-02 15:04:05.0 -0700 GMT", datestr)
 			}
 		}
 		if err == nil {

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -303,6 +303,46 @@ func TestParse(t *testing.T) {
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
 	assert.T(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
+	ts, err = ParseAny("2014-04-26 17:24:37.123456 UTC")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-26 17:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.123 UTC")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.12 UTC")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-26 17:24:37.12 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.1 UTC")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-26 17:24:37.1 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.123 +0800")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-26 09:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.123 -0800")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-27 01:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.123456 +0800")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-26 09:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2014-04-26 17:24:37.123456 -0800")
+	assert.Tf(t, err == nil, "%v", err)
+	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
+	assert.T(t, "2014-04-27 01:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
 	ts, err = ParseAny("2014-12-16 06:20:00 UTC")
 	assert.Tf(t, err == nil, "%v", err)
 	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))


### PR DESCRIPTION
Cover all dates with fractional seconds from 2006-01-02 15:04:05.000000000  to 2006-01-02 15:04:05.0 with option +0000 and +0000 UTC timezones.