### PR TITLE
remove unnecessary dependencies

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -6,8 +6,6 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
-
-	u "github.com/araddon/gou"
 )
 
 type DateState int
@@ -44,8 +42,6 @@ const (
 	ST_WEEKDAYABBREVCOMMA
 )
 
-var _ = u.EMPTY
-
 var (
 	shortDates    = []string{"01/02/2006", "1/2/2006", "06/01/02", "01/02/06", "1/2/06"}
 	weekdays      = map[string]bool{"Monday": true, "Tuesday": true, "Wednesday": true, "Thursday": true, "Friday": true, "Saturday": true, "Sunday": true}
@@ -79,7 +75,6 @@ iterRunes:
 			i += (bytesConsumed - 1)
 		}
 
-		//u.Infof("char=%s i=%d   datestr=%s", r, i, datestr)
 		switch state {
 		case ST_START:
 			if unicode.IsDigit(r) {
@@ -303,7 +298,6 @@ iterRunes:
 					return time.Time{}, err
 				}
 			default:
-				//u.LogThrottle(u.WARN, 5, "ST_ALPHAWSALPHA case not found: %v", datestr)
 			}
 		case ST_ALPHA: // starts alpha
 			// May 8, 2009 5:57:51 PM
@@ -449,10 +443,8 @@ iterRunes:
 					return time.Time{}, err
 				}
 			default:
-				//u.LogThrottle(u.WARN, 5, "ST_ALPHAWSALPHA case not found: %v", datestr)
 			}
 		default:
-			//u.Infof("no case for: %d", state)
 			break iterRunes
 		}
 	}
@@ -721,7 +713,6 @@ iterRunes:
 				if t, err := time.Parse("2006/01/02", datestr); err == nil {
 					return t, nil
 				} else {
-					u.Errorf("hm: %v   %s", err, datestr)
 					return time.Time{}, err
 				}
 			} else {
@@ -937,8 +928,6 @@ iterRunes:
 		} else {
 			return time.Time{}, err
 		}
-	default:
-		//u.Infof("no case for: %d : %s", state, datestr)
 	}
 
 	return time.Time{}, fmt.Errorf("Could not find date format for %s", datestr)

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -2,11 +2,9 @@ package dateparse
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
-
-	u "github.com/araddon/gou"
-	"github.com/bmizerany/assert"
 )
 
 /*
@@ -54,351 +52,303 @@ import (
 	2006
 
 */
+func tt(t *testing.T, result bool, cd int, args ...interface{}) {
+	fn := func() {
+		t.Errorf("!  Failure")
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	if !result {
+		_, file, line, _ := runtime.Caller(cd + 1)
+		t.Errorf("%s:%d", file, line)
+		fn()
+		t.FailNow()
+	}
+}
 
-func init() {
-	u.SetupLogging("debug")
-	u.SetColorOutput()
+func assert(t *testing.T, result bool, v ...interface{}) {
+	tt(t, result, 1, v...)
+}
+
+func assertf(t *testing.T, result bool, f string, v ...interface{}) {
+	tt(t, result, 1, fmt.Sprintf(f, v...))
 }
 
 func TestParse(t *testing.T) {
 
 	zeroTime := time.Time{}.Unix()
 	ts, err := ParseAny("INVALID")
-	assert.T(t, ts.Unix() == zeroTime)
-	assert.T(t, err != nil)
-
-	//u.Debug(time.Now())  //              2015-08-10 10:23:17.675810275 -0700 PDT
-	//u.Debug(time.Now().In(time.UTC))  // 2015-08-10 17:23:17.675849992 +0000 UTC
+	assert(t, ts.Unix() == zeroTime)
+	assert(t, err != nil)
 
 	ts, err = ParseAny("May 8, 2009 5:57:51 PM")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2009-05-08 17:57:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "2009-05-08 17:57:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//   ANSIC       = "Mon Jan _2 15:04:05 2006"
 	ts, err = ParseAny("Mon Jan  2 15:04:05 2006")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2006-01-02 15:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "2006-01-02 15:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//   UnixDate    = "Mon Jan _2 15:04:05 MST 2006"
 	ts, err = ParseAny("Mon Jan  2 15:04:05 MST 2006")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2006-01-02 15:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "2006-01-02 22:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	// RubyDate    = "Mon Jan 02 15:04:05 -0700 2006"
 	ts, err = ParseAny("Mon Jan 02 15:04:05 -0700 2006")
-	//u.Debug(fmt.Sprintf("%v", ts.In(time.UTC)), "  ---- ", ts)
 	// Are we SURE this is right time?
-	assert.T(t, "2006-01-02 15:04:05 -0700 -0700" == fmt.Sprintf("%v", ts))
+	assert(t, "2006-01-02 15:04:05 -0700 MST" == fmt.Sprintf("%v", ts))
 
 	// RFC850    = "Monday, 02-Jan-06 15:04:05 MST"
 	ts, err = ParseAny("Monday, 02-Jan-06 15:04:05 MST")
-	//u.Debug(fmt.Sprintf("%v", ts.In(time.UTC)), "  ---- ", ts)
-	assert.T(t, "2006-01-02 15:04:05 +0000 MST" == fmt.Sprintf("%v", ts))
+	assert(t, "2006-01-02 15:04:05 -0700 MST" == fmt.Sprintf("%v", ts))
 
 	// Another weird one, year on the end after UTC?
 	ts, err = ParseAny("Mon Aug 10 15:44:11 UTC+0100 2015")
-	assert.T(t, err == nil)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2015-08-10 15:44:11 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, err == nil)
+	assert(t, "2015-08-10 15:44:11 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	// Easily the worst Date format i have ever seen
 	//  "Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)"
 	ts, err = ParseAny("Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)")
-	//u.Debug(fmt.Sprintf("%v", ts.In(time.UTC)), "  ---- ", ts.In(time.UTC))
-	assert.T(t, "2015-07-03 17:04:07 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "2015-07-03 17:04:07 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("Mon, 02 Jan 2006 15:04:05 MST")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2006-01-02 15:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2006-01-02 22:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("Mon, 02 Jan 2006 15:04:05 -0700")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2006-01-02 22:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2006-01-02 22:04:05 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	// not sure if this is anything close to a standard, never seen it before
 	ts, err = ParseAny("12 Feb 2006, 19:17")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2006-02-12 19:17:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2006-02-12 19:17:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2015-02-18 00:12:00 +0000 GMT")
-	assert.Tf(t, err == nil, "%v", err)
-	assert.T(t, "2015-02-18 00:12:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2015-02-18 00:12:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	// Golang Native Format
 	ts, err = ParseAny("2015-02-18 00:12:00 +0000 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	assert.T(t, "2015-02-18 00:12:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2015-02-18 00:12:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//---------------------------------------------
 	//   mm/dd/yyyy ?
 
 	ts, err = ParseAny("3/31/2014")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("03/31/2014")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	// what type of date is this? 08/21/71
 	ts, err = ParseAny("08/21/71")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "1971-08-21 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "1971-08-21 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	// m/d/yy
 	ts, err = ParseAny("8/1/71")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "1971-08-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "1971-08-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("4/8/2014 22:05")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("04/08/2014 22:05")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("04/2/2014 4:00:51")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-02 04:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-02 04:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 01:00:01 PM")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 13:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "1965-08-08 13:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 12:00:01 AM")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 00:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "1965-08-08 00:00:01 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 01:00 PM")
-	//	u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 1:00 PM")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "1965-08-08 13:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("8/8/1965 12:00 AM")
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC), "  error ", err)
-	assert.T(t, "1965-08-08 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assert(t, "1965-08-08 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("4/02/2014 03:00:51")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("03/19/2012 10:11:59")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-03-19 10:11:59 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-03-19 10:11:59 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("03/19/2012 10:11:59.3186369")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-03-19 10:11:59.3186369 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-03-19 10:11:59.3186369 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//---------------------------------------------
 	//   yyyy/mm/dd ?
 
 	ts, err = ParseAny("2014/3/31")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014/03/31")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-03-31 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014/4/8 22:05")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014/04/08 22:05")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-08 22:05:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014/04/2 03:00:51")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014/4/02 03:00:51")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-02 03:00:51 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2012/03/19 10:11:59")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-03-19 10:11:59 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-03-19 10:11:59 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2012/03/19 10:11:59.3186369")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-03-19 10:11:59.3186369 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-03-19 10:11:59.3186369 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//---------------------------------------------
 	//   yyyy-mm-dd ?
 	ts, err = ParseAny("2009-08-12T22:15:09-07:00")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2009-08-13 05:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-13 05:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2009-08-12T22:15:09Z")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC))
-	assert.T(t, "2009-08-12 22:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2009-08-12T22:15:09")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC))
-	assert.T(t, "2009-08-12 22:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.3186369")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37.3186369 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37.3186369 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//                  2015-06-25 01:25:37.115208593 +0000 UTC
 	ts, err = ParseAny("2012-08-03 18:31:59.257000000 +0000 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-08-03 18:31:59.257 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-08-03 18:31:59.257 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2015-09-30 18:48:56.35272715 +0000 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2015-09-30 18:48:56.35272715 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2015-09-30 18:48:56.35272715 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2017-01-27 00:07:31.945167")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2017-01-27 00:07:31.945167 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2017-01-27 00:07:31.945167 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2012-08-03 18:31:59.257000000")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-08-03 18:31:59.257 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-08-03 18:31:59.257 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2013-04-01 22:43:22")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2013-04-01 22:43:22 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2013-04-01 22:43:22 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123456 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.12 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37.12 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37.12 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.1 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37.1 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37.1 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123 +0800")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 09:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 09:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123 -0800")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-27 01:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-27 01:24:37.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123456 +0800")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 09:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 09:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 17:24:37.123456 -0800")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-27 01:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-27 01:24:37.123456 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-12-16 06:20:00 UTC")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-12-16 06:20:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-12-16 06:20:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-12-16 06:20:00 GMT")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-12-16 06:20:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-12-16 06:20:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26 05:24:37 PM")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 17:24:37 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 17:24:37 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04-26")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-26 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-26 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-04")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-04-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-04-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("2014-05-11 08:20:13,787")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-05-11 08:20:13.787 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-05-11 08:20:13.787 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	//  yyyymmdd and similar
 	ts, err = ParseAny("2014")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-01-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-01-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("20140601")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2014-06-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2014-06-01 00:00:00 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("1332151919")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2012-03-19 10:11:59 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2012-03-19 10:11:59 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 	ts, err = ParseAny("1384216367189")
-	assert.Tf(t, err == nil, "%v", err)
-	//u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-	assert.T(t, "2013-11-12 00:32:47.189 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2013-11-12 00:32:47.189 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
 }
 
 // func TestWIP(t *testing.T) {
 // 	ts, err := ParseAny("2013-04-01 22:43:22")
-// 	assert.Tf(t, err == nil, "%v", err)
-// 	u.Debug(ts.In(time.UTC).Unix(), ts.In(time.UTC))
-// 	assert.T(t, "2013-04-01 22:43:22 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+// 	assertf(t, err == nil, "%v", err)
+// 	assert(t, "2013-04-01 22:43:22 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 // }


### PR DESCRIPTION
Remove assert library which has been deprecated and just clone the functions locally for now.  In the future this should be just changed to if statements and testing.T.

Also there were a number of broken tests that were fixed.