### PR TITLE
Parse another format

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -209,22 +209,9 @@ iterRunes:
 					return time.Time{}, err
 				}
 			} else {
-				// updated to include timestamps of different precisions
-				if t, err := time.Parse("2006-01-02T15:04:05.999999999Z", datestr); err == nil {
+				if t, err := time.Parse("2006-01-02T15:04:05Z", datestr); err == nil {
 					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.99999999Z", datestr); err == nil {
-					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.9999999Z", datestr); err == nil {
-					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.999999Z", datestr); err == nil {
-					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.99999Z", datestr); err == nil {
-					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.9999Z", datestr); err == nil {
-					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.999Z", datestr); err == nil {
-					return t, nil
-				} else if t, err := time.Parse("2006-01-02T15:04:05.99Z", datestr); err == nil {
+				} else if t, err := time.Parse("2006-01-02T15:04:05", datestr); err == nil {
 					return t, nil
 				} else {
 					return time.Time{}, err

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -270,6 +270,30 @@ func TestParse(t *testing.T) {
 	assertf(t, err == nil, "%v", err)
 	assert(t, "2009-08-12 22:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
 
+	ts, err = ParseAny("2009-08-12T22:15:09.99Z")
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09.99 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2009-08-12T22:15:09.9999Z")
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09.9999 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2009-08-12T22:15:09.99999999Z")
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09.99999999 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2009-08-12T22:15:09.123")
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09.123 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2009-08-12T22:15:09.12")
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09.12 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
+	ts, err = ParseAny("2009-08-12T22:15:09.1")
+	assertf(t, err == nil, "%v", err)
+	assert(t, "2009-08-12 22:15:09.1 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))
+
 	ts, err = ParseAny("2009-08-12T22:15:09")
 	assertf(t, err == nil, "%v", err)
 	assert(t, "2009-08-12 22:15:09 +0000 UTC" == fmt.Sprintf("%v", ts.In(time.UTC)))


### PR DESCRIPTION
Parses new format `2009-08-12T22:15:09.123`

Also cleans up code on date time that end with .xxxZ which is parsed simply by `2006-01-02T15:04:05Z` 
