### PR TITLE
disable timeutils test to prevent depending on mgo

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/simplereach/timeutils"
 )
 
 /*
@@ -44,6 +42,7 @@ func BenchmarkParseAny(b *testing.B) {
 	}
 }
 
+/*
 func BenchmarkParseDateString(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -52,6 +51,7 @@ func BenchmarkParseDateString(b *testing.B) {
 		}
 	}
 }
+*/
 
 var (
 	testDates = []string{


### PR DESCRIPTION
Currently `timeutils` benchmark ends up pulling in `mgo` as a dependency to other projects. Comment out the test so it's not a strict requirement.

Unfortunately, didn't find a nice way to avoid creating a dependency and still make benchmarks work with a special flag.