### PR TITLE
Refactor to use scylladb/termtables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/apcera/termtables"
+	"github.com/scylladb/termtables"
 	"github.com/araddon/dateparse"
 )
 

--- a/dateparse/main.go
+++ b/dateparse/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/apcera/termtables"
+	"github.com/scylladb/termtables"
 	"github.com/araddon/dateparse"
 )
 

--- a/example/main.go
+++ b/example/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/apcera/termtables"
+	"github.com/scylladb/termtables"
 	"github.com/araddon/dateparse"
 )
 


### PR DESCRIPTION
Hello @araddon,

While I was packaging your library for Debian, 
I have noticed that one of your dependency is not anymore available.

As you may all already know, apcera/termtables has come to a end.

This commit refactor to use the fork from scylladb.
ScyllaDB is an organization, so there's less chance that their
own fork goes offline too.

This PR fix #90 and is a lighter fix than the one proposed in #89 (vendoring termtables) because there's nothing else than repairing the library in this PR.

I don't know what do you think about this. Just let me know If you have another solution.
I require your library to package another one, so this fix is really important for me, and I'm willing to take time to do it in another way if you prefer.

Cheers