### PR TITLE
Fix possible panic

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -240,7 +240,7 @@ func parseTime(datestr string, loc *time.Location, opts ...ParserOption) (p *par
 		// this is because it means that a day is being interpreted as a month and overflowing the valid value for that
 		// by retrying in this case, we can fix a common situation with no assumptions
 		defer func() {
-			if p.ambiguousMD {
+			if p != nil && p.ambiguousMD {
 				// if it errors out with the following error, swap before we
 				// get out of this function to reduce scope it needs to be applied on
 				_, err := p.parse()

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -520,6 +520,9 @@ func TestParseErrors(t *testing.T) {
 	for _, th := range testParseErrors {
 		v, err := ParseAny(th.in)
 		assert.NotEqual(t, nil, err, "%v for %v", v, th.in)
+
+		v, err = ParseAny(th.in, RetryAmbiguousDateWithSwap(true))
+		assert.NotEqual(t, nil, err, "%v for %v", v, th.in)
 	}
 }
 


### PR DESCRIPTION
When parse invalid date with `RetryAmbiguousDateWithSwap(true)` option, returned `p` will be nil, and the deffered function will panic, the added test could reproduce the issue.