### PR TITLE
fix problem with date format 02.01.2006

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -374,10 +374,20 @@ iterRunes:
 					p.setYear()
 				} else {
 					p.ambiguousMD = true
-					p.moi = 0
-					p.molen = i
-					p.setMonth()
-					p.dayi = i + 1
+					if p.preferMonthFirst {
+						if p.molen == 0 {
+							// 03.31.2005
+							p.molen = i
+							p.setMonth()
+							p.dayi = i + 1
+						}
+					} else {
+						if p.daylen == 0 {
+							p.daylen = i
+							p.setDay()
+							p.moi = i + 1
+						}
+					}
 				}
 
 			case ' ':
@@ -726,9 +736,15 @@ iterRunes:
 					p.yeari = i + 1
 					p.setDay()
 					p.stateDate = dateDigitDotDot
+				} else if p.dayi == 0 && p.yearlen == 0 {
+					// 23.07.2002
+					p.molen = i - p.moi
+					p.yeari = i + 1
+					p.setMonth()
+					p.stateDate = dateDigitDotDot
 				} else {
 					// 2018.09.30
-					//p.molen = 2
+					// p.molen = 2
 					p.molen = i - p.moi
 					p.dayi = i + 1
 					p.setMonth()

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -402,6 +402,9 @@ var testInputs = []dateTest{
 	{in: "03.31.2014", out: "2014-03-31 00:00:00 +0000 UTC"},
 	//   mm.dd.yy
 	{in: "08.21.71", out: "1971-08-21 00:00:00 +0000 UTC"},
+	//   dd.mm.yyyy
+	{in: "23.07.1938", out: "1938-07-23 00:00:00 +0000 UTC"},
+	{in: "23/07/1938", out: "1938-07-23 00:00:00 +0000 UTC"},
 	//  yyyymmdd and similar
 	{in: "2014", out: "2014-01-01 00:00:00 +0000 UTC"},
 	{in: "20140601", out: "2014-06-01 00:00:00 +0000 UTC"},
@@ -450,7 +453,7 @@ func TestParse(t *testing.T) {
 				panic("whoops")
 			}
 		} else {
-			ts = MustParse(th.in)
+			ts = MustParse(th.in, RetryAmbiguousDateWithSwap(true))
 			got := fmt.Sprintf("%v", ts.In(time.UTC))
 			assert.Equal(t, th.out, got, "Expected %q but got %q from %q", th.out, got, th.in)
 			if th.out != got {


### PR DESCRIPTION
I've fixed the errors with date formats with the leading date: 02.01.2006, 02/01/2006.
Without fix the ParseAny function was returning the error "month out of range".

Tests were added.