### PR TITLE
support combined datetime format with subseconds (yyyyMMddhhmmss.SSS)

### DIFF
--- a/parseany.go
+++ b/parseany.go
@@ -372,13 +372,15 @@ iterRunes:
 					p.yearlen = i
 					p.moi = i + 1
 					p.setYear()
-				} else {
+				} else if i <= 2 {
 					p.ambiguousMD = true
 					p.moi = 0
 					p.molen = i
 					p.setMonth()
 					p.dayi = i + 1
 				}
+				// else this might be a unixy combined datetime of the form:
+				// yyyyMMddhhmmss.SSS
 
 			case ' ':
 				// 18 January 2018
@@ -1847,10 +1849,15 @@ iterRunes:
 		return p, nil
 
 	case dateDigitDot:
-		// 2014.05
-		p.molen = i - p.moi
-		p.setMonth()
-		return p, nil
+		if len(datestr) == len("yyyyMMddhhmmss.SSS") { // 18
+			p.format = []byte("20060102150405.000")
+			return p, nil
+		} else {
+			// 2014.05
+			p.molen = i - p.moi
+			p.setMonth()
+			return p, nil
+		}
 
 	case dateDigitDotDot:
 		// 03.31.1981

--- a/parseany_test.go
+++ b/parseany_test.go
@@ -406,6 +406,7 @@ var testInputs = []dateTest{
 	{in: "2014", out: "2014-01-01 00:00:00 +0000 UTC"},
 	{in: "20140601", out: "2014-06-01 00:00:00 +0000 UTC"},
 	{in: "20140722105203", out: "2014-07-22 10:52:03 +0000 UTC"},
+	{in: "20140722105203.364", out: "2014-07-22 10:52:03.364 +0000 UTC"},
 	// yymmdd hh:mm:yy  mysql log  https://github.com/araddon/dateparse/issues/119
 	// 080313 05:21:55 mysqld started
 	// 080313 5:21:55 InnoDB: Started; log sequence number 0 43655


### PR DESCRIPTION
Fixes #143

Signed-off-by: Daniel Ferstay <dferstay@splunk.com>